### PR TITLE
repository name을 소문자로 fix하기

### DIFF
--- a/.github/workflows/build-dev-image.yaml
+++ b/.github/workflows/build-dev-image.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           push: true
           tags: |
-            "ghcr.io/NewWays-TechForImpactKAIST/backend:${{ env.IMAGE_TAG }}"
+            "ghcr.io/newways-techforimpactkaist/backend:${{ env.IMAGE_TAG }}"
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## Summary

- GitHub Packages에 패키지를 게시하려면 레포지토리 이름/organization 이름이 소문자여야 합니다.